### PR TITLE
修复近期遇到的几个问题

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,8 +3,9 @@
     ["env", {
       "modules": false,
       "targets": {
-        "browsers": ["> 1%", "last 2 versions", "not ie <= 8"]
-      }
+        "browsers": ["> 1%", "last 2 versions", "not ie <= 9"]
+      },
+      "useBuiltIns": true
     }],
     "stage-2"
   ],

--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -12,8 +12,8 @@ function resolve (dir) {
 
 module.exports = {
   entry: {
-    'oj': ['babel-polyfill', './src/pages/oj/index.js'],
-    'admin': ['babel-polyfill', './src/pages/admin/index.js']
+    'oj': ['./src/pages/oj/index.js'],
+    'admin': ['./src/pages/admin/index.js']
   },
   output: {
     path: config.build.assetsRoot,

--- a/config/index.js
+++ b/config/index.js
@@ -1,9 +1,15 @@
-
 'use strict'
 // Template version: 1.1.1
 // see http://vuejs-templates.github.io/webpack for documentation.
 
 const path = require('path')
+const commonProxy = {
+  onProxyReq: (proxyReq, req, res) => {
+    proxyReq.setHeader('Referer', process.env.TARGET)
+  },
+  target: process.env.TARGET,
+  changeOrigin: true
+}
 
 module.exports = {
   build: {
@@ -35,14 +41,8 @@ module.exports = {
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
     proxyTable: {
-      "/api": {
-        target: process.env.TARGET,
-        changeOrigin: true
-      },
-      "/public": {
-        target: process.env.TARGET,
-        changeOrigin: true
-      }
+      "/api": commonProxy,
+      "/public": commonProxy
     },
     // CSS Sourcemaps off by default because relative paths are "buggy"
     // with this option, according to the CSS-Loader README

--- a/src/pages/admin/index.js
+++ b/src/pages/admin/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import Vue from 'vue'
 import App from './App.vue'
 import Element from 'element-ui'

--- a/src/pages/oj/index.js
+++ b/src/pages/oj/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import Vue from 'vue'
 import App from './App.vue'
 import router from './router'

--- a/src/pages/oj/views/problem/Problem.vue
+++ b/src/pages/oj/views/problem/Problem.vue
@@ -511,13 +511,13 @@
     .sample {
       align-items: stretch;
       &-input, &-output {
-        flex: 1 1;
+        flex: 1 1 auto;
         display: flex;
         flex-direction: column;
         margin-right: 5%;
       }
       pre {
-        flex: 1 1;
+        flex: 1 1 auto;
         align-self: stretch;
         border-style: solid;
         background: transparent;

--- a/src/pages/oj/views/problem/Problem.vue
+++ b/src/pages/oj/views/problem/Problem.vue
@@ -198,6 +198,9 @@
   import api from '@oj/api'
   import { pie, largePie } from './chartData'
 
+  // 只显示这些状态的图形占用
+  const filtedStatus = ['-1', '-2', '0', '1', '2', '3', '4', '8']
+
   export default {
     name: 'Problem',
     components: {
@@ -292,16 +295,23 @@
         })
       },
       changePie (problemData) {
+        // 只显示特定的一些状态
+        for (let k in problemData.statistic_info) {
+          if (filtedStatus.indexOf(k) === -1) {
+            delete problemData.statistic_info[k]
+          }
+        }
         let acNum = problemData.accepted_number
         let data = [
           {name: 'WA', value: problemData.submission_number - acNum},
           {name: 'AC', value: acNum}
         ]
         this.pie.series[0].data = data
-        // 只selected大图，这里需要做一下deepcopy
+        // 只把大图的AC selected下，这里需要做一下deepcopy
         let data2 = JSON.parse(JSON.stringify(data))
         data2[1].selected = true
         this.largePie.series[1].data = data2
+
         // 根据结果设置legend,没有提交过的legend不显示
         let legend = Object.keys(problemData.statistic_info).map(ele => JUDGE_STATUS[ele].short)
         if (legend.length === 0) {


### PR DESCRIPTION
关于`babel-polyfill`使用`babel-preset-env`可以根据配置仅引入目标浏览器需要的polyfill，大约能比原来缩小几十k的体积。