### PR TITLE
Fix highlight of problems&contests

### DIFF
--- a/src/pages/oj/components/NavBar.vue
+++ b/src/pages/oj/components/NavBar.vue
@@ -6,11 +6,11 @@
         <Icon type="home"></Icon>
         {{$t('m.Home')}}
       </Menu-item>
-      <Menu-item name="/problems">
+      <Menu-item name="/problem">
         <Icon type="ios-keypad"></Icon>
         {{$t('m.NavProblems')}}
       </Menu-item>
-      <Menu-item name="/contests">
+      <Menu-item name="/contest">
         <Icon type="trophy"></Icon>
         {{$t('m.Contests')}}
       </Menu-item>

--- a/src/pages/oj/router/routes.js
+++ b/src/pages/oj/router/routes.js
@@ -47,7 +47,7 @@ export default [
   },
   {
     name: 'problem-list',
-    path: '/problems',
+    path: '/problem',
     meta: {title: 'Problem List'},
     component: ProblemList
   },
@@ -71,7 +71,7 @@ export default [
   },
   {
     name: 'contest-list',
-    path: '/contests',
+    path: '/contest',
     meta: {title: 'Contest List'},
     component: Contest.ContestList
   },


### PR DESCRIPTION
navbar高亮有typo，进入problems/contests内部页面高亮会消失，如下:

![image](https://user-images.githubusercontent.com/25893192/65370681-2b36f700-dc8e-11e9-9736-1b24be7e2946.png)

![image](https://user-images.githubusercontent.com/25893192/65370689-3a1da980-dc8e-11e9-97d7-429cfe809845.png)

