### PR TITLE
Update ACMContestRank.vue

### DIFF
--- a/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -35,7 +35,7 @@
     <div v-show="showChart" class="echarts">
       <ECharts :options="options" ref="chart" auto-resize></ECharts>
     </div>
-    <Table ref="tableRank" class="auto-resize" :columns="columns" :data="dataRank" disabled-hover></Table>
+    <Table ref="tableRank" :columns="columns" :data="dataRank" disabled-hover width="1600" height="600"></Table>
     <Pagination :total="total"
                 :page-size.sync="limit"
                 :current.sync="page"
@@ -67,7 +67,8 @@
         columns: [
           {
             align: 'center',
-            width: 60,
+            width: 50,
+            fixed: 'left',
             render: (h, params) => {
               return h('span', {}, params.index + (this.page - 1) * this.limit + 1)
             }
@@ -75,6 +76,8 @@
           {
             title: 'User',
             align: 'center',
+            fixed: 'left',
+            width: 150,
             render: (h, params) => {
               return h('a', {
                 style: {
@@ -116,6 +119,7 @@
           {
             title: 'TotalTime',
             align: 'center',
+            width: 100,
             render: (h, params) => {
               return h('span', this.parseTotalTime(params.row.total_time))
             }
@@ -268,6 +272,7 @@
           this.columns.push({
             align: 'center',
             key: problem.id,
+            width: problems.length > 15 ? 80 : null,
             renderHeader: (h, params) => {
               return h('a', {
                 'class': {


### PR DESCRIPTION
针对比赛题目数大于15题后，rank界面拥挤变形的问题
尝试固定1、2列，并动态设置列宽，由于需要横向滚动，同时固定了高度
