### PR TITLE
排名页显示修复 & 翻译修正

### DIFF
--- a/src/i18n/oj/en-US.js
+++ b/src/i18n/oj/en-US.js
@@ -233,7 +233,7 @@ export const m = {
   UnShare: 'UnShare',
   Succeeded: 'Succeeded',
   Real_Time: 'Real Time',
-  Singal: 'Singal',
+  Signal: 'Signal',
   // SubmissionList.vue
   When: 'When',
   ID: 'ID',

--- a/src/i18n/oj/zh-CN.js
+++ b/src/i18n/oj/zh-CN.js
@@ -233,7 +233,7 @@ export const m = {
   UnShare: '不分享',
   Succeeded: '成功',
   Real_Time: '真实时间',
-  Singal: '单身',
+  Signal: '信号',
   // SubmissionList.vue
   When: '时间',
   ID: 'ID',

--- a/src/pages/oj/views/contest/ContestDetail.vue
+++ b/src/pages/oj/views/contest/ContestDetail.vue
@@ -207,6 +207,7 @@
   .flex-container {
     #contest-main {
       flex: 1 1;
+      width: 0;
       #contest-desc {
         flex: auto;
       }

--- a/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -35,7 +35,7 @@
     <div v-show="showChart" class="echarts">
       <ECharts :options="options" ref="chart" auto-resize></ECharts>
     </div>
-    <Table ref="tableRank" :columns="columns" :data="dataRank" disabled-hover width="1600" height="600"></Table>
+    <Table ref="tableRank" :columns="columns" :data="dataRank" disabled-hover height="600"></Table>
     <Pagination :total="total"
                 :page-size.sync="limit"
                 :current.sync="page"

--- a/src/pages/oj/views/submission/SubmissionDetails.vue
+++ b/src/pages/oj/views/submission/SubmissionDetails.vue
@@ -133,7 +133,7 @@
                   }
                 },
                 {
-                  title: this.$i18n.t('m.Singal'),
+                  title: this.$i18n.t('m.Signal'),
                   align: 'center',
                   key: 'signal'
                 }


### PR DESCRIPTION
1. 比赛排名页将 1600px 用滚动条代替
1. 修正「单身」的翻译