### PR TITLE
修复Simditor保存后文本颜色丢失等问题

### DIFF
--- a/src/pages/admin/components/Simditor.vue
+++ b/src/pages/admin/components/Simditor.vue
@@ -45,10 +45,10 @@
         }
       })
       this.editor.on('valuechanged', (e, src) => {
-        this.currentValue = this.editor.getValue()
+        this.currentValue = e.target.body[0].innerHTML
       })
       this.editor.on('decorate', (e, src) => {
-        this.currentValue = this.editor.getValue()
+        this.currentValue = e.target.body[0].innerHTML
       })
 
       this.editor.setValue(this.value)


### PR DESCRIPTION
修复Simditor保存后文本颜色丢失等问题
PS：斜体仍旧无效

![image](https://user-images.githubusercontent.com/2792725/101862182-c1fe1500-3bac-11eb-8c8c-a522f31a5d0d.png)
