### PR TITLE
更新关于评分器页面

### DIFF
--- a/src/pages/oj/views/help/About.vue
+++ b/src/pages/oj/views/help/About.vue
@@ -5,7 +5,7 @@
       <div class="content markdown-body">
         <ul>
           <li v-for="lang in languages">{{lang.name}} ( {{lang.description}} )
-            <pre>{{lang.config.compile.compile_command}}</pre>
+            <pre>{{lang.config.compile ? lang.config.compile.compile_command : lang.config.run.command}}</pre>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
- 支持无编译选项的语言显示， 如：PHP， See：https://github.com/QingdaoU/JudgeServer/pull/48