### PR TITLE
 Fixed an error raised when object is undefined in OI contest mode

### DIFF
--- a/src/pages/oj/views/problem/Problem.vue
+++ b/src/pages/oj/views/problem/Problem.vue
@@ -324,6 +324,11 @@
         let data2 = JSON.parse(JSON.stringify(data))
         data2[1].selected = true
         this.largePie.series[1].data = data2
+        
+        // OI模式封榜时statistic_info为空，会导致代码无法正确执行，导致错误（如：代码模板不加载）
+        if (problemData.statistic_info === undefined) {
+          return
+        }
 
         // 根据结果设置legend,没有提交过的legend不显示
         let legend = Object.keys(problemData.statistic_info).map(ele => JUDGE_STATUS[ele].short)


### PR DESCRIPTION
在OI模式下并设置封榜时，problemData.statistic_info为undefined，运行到此处会报错，后续代码无法正常运行。