### PR TITLE
修复codemirror识别当前语言异常

### DIFF
--- a/src/pages/oj/components/CodeMirror.vue
+++ b/src/pages/oj/components/CodeMirror.vue
@@ -160,7 +160,11 @@
     },
     watch: {
       'theme' (newVal, oldVal) {
+        // console.log('theme')
         this.editor.setOption('theme', newVal)
+      },
+      'language' (newVal, oldVal) {
+        this.onLangChange(newVal)
       }
     }
   }


### PR DESCRIPTION
bug描述：第一次进入promblem页面，codemirror识别当前语言异常，总是识别成C++，导致写其他语言时智能缩进，高亮提示等工作不正常
我认为bug原因：进入父problem，子codemirror通过props接收父给的language，理论上父中改了language，子props中language也会动态的修改。但是，父获得真实的language是异步操作，父获得真实language之前，子就已经拿到了默认给的C++，可能父中异步修改的language变量不会同步到子prop？导致子的language没修改成功？以上是我猜的
修复方式：子中watch这个props就可以了，一但父中改动就会主动同步