### PR TITLE
fix: admin User dialog password input not reactive (Vue 2 reactivity caveat)

### DIFF
--- a/src/pages/admin/views/general/User.vue
+++ b/src/pages/admin/views/general/User.vue
@@ -312,9 +312,23 @@
       openUserDialog (id) {
         this.showUserDialog = true
         api.getUser(id).then(res => {
-          this.user = res.data.data
-          this.user.password = ''
-          this.user.real_tfa = this.user.two_factor_auth
+          let data = res.data.data
+          this.user = Object.assign({}, {
+            id: '',
+            username: '',
+            real_name: '',
+            email: '',
+            password: '',
+            admin_type: 'Regular User',
+            problem_permission: 'None',
+            two_factor_auth: false,
+            open_api: false,
+            is_disabled: false,
+            real_tfa: false
+          }, data, {
+            password: '',
+            real_tfa: data.two_factor_auth
+          })
         })
       },
       // 获取用户列表


### PR DESCRIPTION
## Problem

When editing a user in the admin panel, the **New Password** input field is unresponsive — typing has no effect unless another field (e.g. Real Name) is modified first.

Fixes #52, Fixes #124

## Root Cause

In `openUserDialog`, the user object from the API response is assigned directly:

```js
this.user = res.data.data
this.user.password = ''
this.user.real_tfa = this.user.two_factor_auth
```

The API response does not include a `password` property. Vue 2 cannot detect properties added to an object after it has been made reactive ([Vue 2 Reactivity in Depth](https://v2.vuejs.org/v2/guide/reactivity.html#For-Objects)). So `this.user.password = ''` silently adds a non-reactive property — the input appears frozen because Vue never triggers a re-render when it changes.

## Fix

Use `Object.assign` to create a new object with all fields pre-declared (including `password`), then merge the API data on top:

```js
let data = res.data.data
this.user = Object.assign({}, {
  id: '',
  username: '',
  real_name: '',
  email: '',
  password: '',
  admin_type: 'Regular User',
  problem_permission: 'None',
  two_factor_auth: false,
  open_api: false,
  is_disabled: false,
  real_tfa: false
}, data, {
  password: '',
  real_tfa: data.two_factor_auth
})
```

Because `this.user` is reassigned to an entirely new object, Vue 2 makes every property (including `password`) reactive from the start.