### PR TITLE
fix: add missing Go and JavaScript syntax highlighting in admin CodeMirror

### DIFF
--- a/src/pages/admin/components/CodeMirror.vue
+++ b/src/pages/admin/components/CodeMirror.vue
@@ -5,6 +5,8 @@
   import { codemirror } from 'vue-codemirror-lite'
   import 'codemirror/mode/clike/clike.js'
   import 'codemirror/mode/python/python.js'
+  import 'codemirror/mode/go/go.js'
+  import 'codemirror/mode/javascript/javascript.js'
   import 'codemirror/theme/solarized.css'
 
   export default {


### PR DESCRIPTION
## Problem

The admin panel's CodeMirror editor only imports C/C++ (`clike`) and Python syntax modes. Go and JavaScript code renders as plain text without any syntax highlighting.

The OJ frontend's CodeMirror (`src/pages/oj/components/CodeMirror.vue`) already imports both `go` and `javascript` modes, but the admin version (`src/pages/admin/components/CodeMirror.vue`) is missing them.

Fixes #77

## Fix

Add the two missing imports to the admin CodeMirror component:

```js
import 'codemirror/mode/go/go.js'
import 'codemirror/mode/javascript/javascript.js'
```